### PR TITLE
allow main window to be resized

### DIFF
--- a/cmd/nes/main.go
+++ b/cmd/nes/main.go
@@ -239,7 +239,7 @@ func RunNES(path string, debug bool, maxCycles uint64, windowSizeMultiple int, r
 
     /* to resize the window */
     // | sdl.WINDOW_RESIZABLE
-    window, err := sdl.CreateWindow("nes", sdl.WINDOWPOS_UNDEFINED, sdl.WINDOWPOS_UNDEFINED, int32(256 * windowSizeMultiple), int32((240 - overscanPixels * 2) * windowSizeMultiple), sdl.WINDOW_SHOWN)
+    window, err := sdl.CreateWindow("nes", sdl.WINDOWPOS_UNDEFINED, sdl.WINDOWPOS_UNDEFINED, int32(256 * windowSizeMultiple), int32((240 - overscanPixels * 2) * windowSizeMultiple), sdl.WINDOW_SHOWN | sdl.WINDOW_RESIZABLE)
     if err != nil {
         return err
     }

--- a/cmd/nes/main.go
+++ b/cmd/nes/main.go
@@ -302,6 +302,9 @@ func RunNES(path string, debug bool, maxCycles uint64, windowSizeMultiple int, r
     desiredFps := 60.0
     pixelFormat := findPixelFormat()
 
+    /* Show black bars on the sides or top/bottom when the window changes size */
+    renderer.SetLogicalSize(int32(256), int32(240-overscanPixels * 2))
+
     /* create a surface from the pixels in one call, then create a texture and render it */
     doRender := func(screen nes.VirtualScreen, raw_pixels []byte) error {
         width := int32(256)


### PR DESCRIPTION
Resize the window using the normal window manager mechanisms (drag corner). The rendering area always uses the same aspect ratio due to sdl.SetLogicalSize().