### PR TITLE
cache thumbnails shown in the rom loader

### DIFF
--- a/cmd/nes/menu/rom-loader.go
+++ b/cmd/nes/menu/rom-loader.go
@@ -131,8 +131,11 @@ func getSha256(path string) (string, error){
 }
 
 func getHome() string {
-    // FIXME
-    return "/home/jon"
+    home, err := os.UserHomeDir()
+    if err != nil {
+        return os.TempDir()
+    }
+    return home
 }
 
 func dirExists(path string) bool {

--- a/cmd/nes/menu/rom-loader.go
+++ b/cmd/nes/menu/rom-loader.go
@@ -287,7 +287,7 @@ func saveCachedFrame(count int, cachedSha256 string, path string, screen nes.Vir
             return err
         }
     }
-    
+
     metadata := filepath.Join(cachedPath, "metadata")
     err := os.WriteFile(metadata, []byte(getUniqueProgramIdentifier() + "\n"), 0644)
     if err != nil {
@@ -296,7 +296,7 @@ func saveCachedFrame(count int, cachedSha256 string, path string, screen nes.Vir
 
     // write the path of the rom just for info purposes
     os.WriteFile(filepath.Join(cachedPath, "info"), []byte(path + "\n"), 0644)
-    
+
     name := fmt.Sprintf("%v.png", count)
     image := convertToPng(screen)
 
@@ -329,7 +329,7 @@ func generateThumbnails(loaderQuit context.Context, cpu nes.CPUState, romId RomI
 
     buffer := nes.MakeVirtualScreen(nes.VideoWidth, nes.VideoHeight)
     bufferReady <- buffer
-    
+
     var err error
     cachedSha := ""
     if doCache {
@@ -355,7 +355,7 @@ func generateThumbnails(loaderQuit context.Context, cpu nes.CPUState, romId RomI
                         Id: romId,
                         Frame: screen.Copy(),
                     }
-                    
+
                     if doCache {
                         err := saveCachedFrame(frameNumber, cachedSha, path, screen)
                         if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,5 @@ require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/nsf/termbox-go v1.1.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664 // indirect
+	golang.org/x/sys v0.0.0-20220624220833-87e55d714810 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,7 +23,7 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664 h1:wEZYwx+kK+KlZ0hpvP2Ls1Xr4+RWnlzGFwPP0aiDjIU=
-golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220624220833-87e55d714810 h1:rHZQSjJdAI4Xf5Qzeh2bBc5YJIkPFVM6oDtMFYmgws0=
+golang.org/x/sys v0.0.0-20220624220833-87e55d714810/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
Computing the thumbnail frames for each rom is expensive, so save every frame to some directory and then on subsequent loading screens load the saved images instead of running the emulator.

The cached directory is ~/.cache/jon-nes/<sha256 of rom>. The sha256 is stored in the cached rom directory as well, in case the emulator itself changed thus invalidating the frames produced.