### PR TITLE
show info about selected rom

### DIFF
--- a/cmd/nes/menu/menu.go
+++ b/cmd/nes/menu/menu.go
@@ -1744,6 +1744,25 @@ func (loader *LoadRomInfoMenu) GetSelectionColor(use int) sdl.Color {
     return white
 }
 
+/* convert a number into a human readable string, like 2000 => 1.95kb */
+func niceSize(size int64) string {
+    last := "b"
+    if size > 1024 {
+        size /= 1024
+        last = "kb"
+    }
+    if size > 1024 {
+        size /= 1024
+        last = "mb"
+    }
+    if size > 1024 {
+        size /= 1024
+        last = "gb"
+    }
+
+    return fmt.Sprintf("%v%v", size, last)
+}
+
 func (loader *LoadRomInfoMenu) MakeRenderer(maxWidth int, maxHeight int, buttonManager *ButtonManager, textureManager *TextureManager, font *ttf.Font, smallFont *ttf.Font) common.RenderFunction {
     old := loader.RomLoader.MakeRenderer(maxWidth, maxHeight, buttonManager, textureManager, font, smallFont)
 
@@ -1787,7 +1806,17 @@ func (loader *LoadRomInfoMenu) MakeRenderer(maxWidth int, maxHeight int, buttonM
 
         info, ok := loader.RomLoader.LoaderState.GetSelectedRomInfo()
         if ok {
-            writeFont(font, renderer, x, y, fmt.Sprintf("%v", filepath.Base(info.Path)), white)
+            textY := y
+            textX := x
+            writeFont(font, renderer, textX, textY, fmt.Sprintf("%v", filepath.Base(info.Path)), white)
+
+            textY += font.Height() + 2
+
+            stat, err := os.Stat(info.Path)
+            if err == nil {
+                writeFont(font, renderer, textX, textY, fmt.Sprintf("File size: %v", niceSize(stat.Size())), white)
+                textY += font.Height() + 2
+            }
 
             frame, ok := info.GetFrame()
             if ok {

--- a/cmd/nes/menu/menu.go
+++ b/cmd/nes/menu/menu.go
@@ -1666,8 +1666,13 @@ func (loadRomMenu *LoadRomMenu) Input(input MenuInput) SubMenu {
             loadRomMenu.LoaderCancel()
             return loadRomMenu.Back(loadRomMenu)
         case MenuSelect:
+            return &LoadRomInfoMenu{
+                RomLoader: loadRomMenu,
+            }
+            /*
             loadRomMenu.SelectRom()
             return loadRomMenu
+            */
         default:
             return loadRomMenu
     }
@@ -1681,6 +1686,62 @@ func (loadRomMenu *LoadRomMenu) MakeRenderer(maxWidth int, maxHeight int, button
 
 func (loadRomMenu *LoadRomMenu) UpdateWindowSize(x int, y int){
     loadRomMenu.LoaderState.UpdateWindowSize(x, y)
+}
+
+/* displays info about a specific rom in the rom loader and gives the user a choice to actually load the rom or not */
+type LoadRomInfoMenu struct {
+    RomLoader *LoadRomMenu // the previous load rom menu
+}
+
+func (loader *LoadRomInfoMenu) Input(input MenuInput) SubMenu {
+    switch input {
+        case MenuNext:
+            return loader
+        case MenuPrevious:
+            return loader
+        case MenuUp:
+            return loader
+        case MenuDown:
+            return loader
+        case MenuQuit:
+            return loader.RomLoader
+        case MenuSelect:
+            loader.RomLoader.SelectRom()
+            return loader.RomLoader
+        default:
+            return loader
+    }
+}
+
+func (loader *LoadRomInfoMenu) MakeRenderer(maxWidth int, maxHeight int, buttonManager *ButtonManager, textureManager *TextureManager, font *ttf.Font, smallFont *ttf.Font) common.RenderFunction {
+    old := loader.RomLoader.MakeRenderer(maxWidth, maxHeight, buttonManager, textureManager, font, smallFont)
+
+    return func(renderer *sdl.Renderer) error {
+        err := old(renderer)
+        if err != nil {
+            return err
+        }
+
+        err = renderer.SetDrawBlendMode(sdl.BLENDMODE_BLEND)
+        _ = err
+        renderer.SetDrawColor(0, 64, 0, 230)
+        renderer.FillRect(&sdl.Rect{X: int32(50), Y: int32(50), W: int32(maxWidth - 100), H: int32(maxHeight - 100)})
+
+        return nil
+
+        // return loadRomMenu.LoaderState.Render(maxWidth, maxHeight, font, smallFont, renderer, textureManager)
+    }
+}
+
+func (loader *LoadRomInfoMenu) PlayBeep() {
+    loader.RomLoader.PlayBeep()
+}
+
+func (loader *LoadRomInfoMenu) RawInput(event sdl.Event){
+}
+
+func (loader *LoadRomInfoMenu) UpdateWindowSize(x int, y int){
+    loader.RomLoader.UpdateWindowSize(x, y)
 }
 
 func MakeMainMenu(menu *Menu, mainCancel context.CancelFunc, programActions chan<- common.ProgramActions, joystickStateChanges <-chan JoystickState, joystickManager *common.JoystickManager, textureManager *TextureManager) SubMenu {

--- a/cmd/nes/menu/rom-loader.go
+++ b/cmd/nes/menu/rom-loader.go
@@ -51,6 +51,7 @@ type RomLoaderInfo struct {
 }
 
 func (info *RomLoaderInfo) GetFrame() (nes.VirtualScreen, bool) {
+    // FIXME: might need a lock here
     if len(info.Frames) > 0 {
         return info.Frames[info.ShowFrame], true
     }
@@ -513,6 +514,19 @@ func (loader *RomLoaderState) UpdateWindowSize(width int, height int){
 
     loader.WindowSizeWidth = width
     loader.WindowSizeHeight = height
+}
+
+func (loader *RomLoaderState) GetSelectedRomInfo() (*RomLoaderInfo, bool) {
+    loader.Lock.Lock()
+    defer loader.Lock.Unlock()
+
+    if loader.SelectedRomKey != "" {
+        roms := loader.RomIdsAndPaths.All()
+        index := loader.FindSortedIdIndex(roms, loader.SelectedRomKey)
+        return loader.Roms[roms[index].Id], true
+    }
+
+    return nil, false
 }
 
 func (loader *RomLoaderState) GetSelectedRom() (string, bool) {


### PR DESCRIPTION
Before opening a rom, show an info panel when a rom is selected. The user can then choose to actually load the rom, or go back to the rom selection window.

![image](https://user-images.githubusercontent.com/333508/175861326-32df9b0a-84ac-4f27-bdad-a5a02619e9c3.png)
